### PR TITLE
Require checkout receipt uploads and add complaint management

### DIFF
--- a/app/controllers/AdminController.php
+++ b/app/controllers/AdminController.php
@@ -38,6 +38,12 @@ class AdminController extends Controller
         $orders = (new Order())->all();
         $this->render('admin/orders', compact('orders'), 'admin');
     }
+    public function receipts()
+    {
+        Auth::requireAdmin();
+        $orders = (new Order())->withReceipt();
+        $this->render('admin/receipts', compact('orders'), 'admin');
+    }
     public function order($id)
     {
         Auth::requireAdmin();
@@ -45,6 +51,12 @@ class AdminController extends Controller
         $order = $m->find($id);
         $items = $m->items($id);
         $this->render('admin/order_view', compact('order', 'items'), 'admin');
+    }
+    public function complaints()
+    {
+        Auth::requireAdmin();
+        $complaints = (new Complaint())->all();
+        $this->render('admin/complaints', compact('complaints'), 'admin');
     }
     public function status()
     {

--- a/app/controllers/CheckoutController.php
+++ b/app/controllers/CheckoutController.php
@@ -8,6 +8,45 @@ class CheckoutController extends Controller {
         return $isAjax || $hasPartial;
     }
 
+    protected function uploadReceipt(){
+        $file = $_FILES['payment_receipt'] ?? null;
+        if (empty($file['name'])) {
+            throw new Exception('Debes adjuntar la imagen del comprobante de pago.');
+        }
+
+        if (($file['error'] ?? UPLOAD_ERR_OK) !== UPLOAD_ERR_OK) {
+            throw new Exception('Ocurrió un error al subir el comprobante.');
+        }
+
+        $info = @getimagesize($file['tmp_name']);
+        if ($info === false) {
+            throw new Exception('El comprobante debe ser una imagen válida (JPG, PNG o WEBP).');
+        }
+
+        $allowed = [
+            IMAGETYPE_JPEG => 'jpg',
+            IMAGETYPE_PNG  => 'png',
+            IMAGETYPE_WEBP => 'webp',
+        ];
+        $type = $info[2];
+        if (!isset($allowed[$type])) {
+            throw new Exception('Formato de comprobante no soportado. Usa JPG, PNG o WEBP.');
+        }
+
+        if (!is_dir(UPLOAD_DIR)) {
+            mkdir(UPLOAD_DIR, 0775, true);
+        }
+
+        $filename = 'receipt_' . time() . '_' . bin2hex(random_bytes(4)) . '.' . $allowed[$type];
+        $destination = UPLOAD_DIR . $filename;
+
+        if (!move_uploaded_file($file['tmp_name'], $destination)) {
+            throw new Exception('No se pudo guardar el comprobante. Intenta nuevamente.');
+        }
+
+        return 'public/uploads/' . $filename;
+    }
+
     public function form(){
         $cart = isset($_SESSION['cart']) ? $_SESSION['cart'] : [];
         if (empty($cart)) { 
@@ -46,6 +85,7 @@ class CheckoutController extends Controller {
         ];
 
         try {
+            $data['payment_receipt'] = $this->uploadReceipt();
             $orderModel = new Order();
             $orderId = $orderModel->create($data, $cart);
 
@@ -66,6 +106,14 @@ class CheckoutController extends Controller {
 
         } catch (Exception $e) {
             $error = $e->getMessage();
+
+            if (!empty($data['payment_receipt'] ?? '')) {
+                $stored = UPLOAD_DIR . basename($data['payment_receipt']);
+                if (is_file($stored)) {
+                    @unlink($stored);
+                }
+                unset($data['payment_receipt']);
+            }
 
             if ($this->isPartialReq()) {
                 // En modal: devolver el form con el error (sin layout)

--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -13,5 +13,40 @@ class HomeController extends Controller {
         $settings = (new Setting())->get();
         $this->render('frontend/contact', compact('settings'));
     }
+    public function complaint(){
+        $this->render('frontend/complaint');
+    }
+    public function complaint_submit(){
+        if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+            $this->redirect('home/complaint');
+        }
+
+        $data = [
+            'full_name'  => trim($_POST['full_name'] ?? ''),
+            'document'   => trim($_POST['document'] ?? ''),
+            'email'      => trim($_POST['email'] ?? ''),
+            'phone'      => trim($_POST['phone'] ?? ''),
+            'order_code' => trim($_POST['order_code'] ?? ''),
+            'type'       => trim($_POST['type'] ?? 'Reclamo'),
+            'description'=> trim($_POST['description'] ?? ''),
+        ];
+
+        $errors = [];
+        if ($data['full_name'] === '') { $errors[] = 'Ingresa tu nombre completo.'; }
+        if ($data['email'] === '' || !filter_var($data['email'], FILTER_VALIDATE_EMAIL)) { $errors[] = 'Ingresa un correo válido.'; }
+        if ($data['description'] === '') { $errors[] = 'Describe tu reclamo o queja.'; }
+        if (!in_array($data['type'], ['Reclamo','Queja','Consulta'], true)) { $data['type'] = 'Reclamo'; }
+
+        if ($errors) {
+            $error = implode(' ', $errors);
+            $old = $data;
+            $this->render('frontend/complaint', compact('error','old'));
+            return;
+        }
+
+        (new Complaint())->create($data);
+        $success = 'Tu registro en el libro de reclamaciones se ha enviado correctamente. Pronto nos pondremos en contacto.';
+        $this->render('frontend/complaint', compact('success'));
+    }
 }
 ?>

--- a/app/models/Complaint.php
+++ b/app/models/Complaint.php
@@ -1,0 +1,28 @@
+<?php
+class Complaint {
+    private $db;
+
+    public function __construct(){
+        $this->db = Database::getInstance();
+    }
+
+    public function create($data){
+        $stmt = $this->db->prepare('INSERT INTO complaints (full_name, document, email, phone, order_code, type, description) VALUES (?,?,?,?,?,?,?)');
+        $stmt->execute([
+            $data['full_name'],
+            $data['document'],
+            $data['email'],
+            $data['phone'],
+            $data['order_code'],
+            $data['type'],
+            $data['description'],
+        ]);
+        return $this->db->lastInsertId();
+    }
+
+    public function all(){
+        $stmt = $this->db->query('SELECT * FROM complaints ORDER BY id DESC');
+        return $stmt->fetchAll();
+    }
+}
+?>

--- a/app/models/Order.php
+++ b/app/models/Order.php
@@ -5,8 +5,8 @@ class Order {
     public function create($data, $items) {
         $this->db->beginTransaction();
         try {
-            $stmt = $this->db->prepare('INSERT INTO orders (customer_name,customer_email,customer_phone,customer_address,total,status,created_at) VALUES (?,?,?,?,?,"PENDIENTE",NOW())');
-            $stmt->execute([$data['name'],$data['email'],$data['phone'],$data['address'],$data['total']]);
+            $stmt = $this->db->prepare('INSERT INTO orders (customer_name,customer_email,customer_phone,customer_address,total,payment_receipt,status,created_at) VALUES (?,?,?,?,?,?,"PENDIENTE",NOW())');
+            $stmt->execute([$data['name'],$data['email'],$data['phone'],$data['address'],$data['total'],$data['payment_receipt']]);
             $orderId = $this->db->lastInsertId();
 
             $stmtItem = $this->db->prepare('INSERT INTO order_items (order_id,product_id,quantity,unit_price,subtotal) VALUES (?,?,?,?,?)');
@@ -27,6 +27,9 @@ class Order {
     }
     public function all(){
         return $this->db->query('SELECT * FROM orders ORDER BY id DESC')->fetchAll();
+    }
+    public function withReceipt(){
+        return $this->db->query('SELECT * FROM orders WHERE payment_receipt <> "" ORDER BY id DESC')->fetchAll();
     }
     public function find($id){
         $s=$this->db->prepare('SELECT * FROM orders WHERE id=?'); $s->execute([$id]); return $s->fetch();

--- a/app/views/admin/complaints.php
+++ b/app/views/admin/complaints.php
@@ -1,0 +1,40 @@
+<h1>Libro de Reclamaciones</h1>
+<p>Listado de registros enviados por los clientes desde el libro de reclamaciones.</p>
+
+<?php if(empty($complaints)): ?>
+  <p>No hay registros disponibles.</p>
+<?php else: ?>
+  <div class="table-wrap">
+    <table class="table">
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Cliente</th>
+          <th>Tipo</th>
+          <th>Contacto</th>
+          <th>Fecha</th>
+          <th>Detalle</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach($complaints as $row): ?>
+          <tr>
+            <td><?php echo $row['id']; ?></td>
+            <td>
+              <strong><?php echo htmlspecialchars($row['full_name']); ?></strong><br>
+              <?php if(!empty($row['document'])): ?>Documento: <?php echo htmlspecialchars($row['document']); ?><br><?php endif; ?>
+              <?php if(!empty($row['order_code'])): ?>Pedido: <?php echo htmlspecialchars($row['order_code']); ?><?php endif; ?>
+            </td>
+            <td><?php echo htmlspecialchars($row['type']); ?></td>
+            <td>
+              <div><?php echo htmlspecialchars($row['email']); ?></div>
+              <?php if(!empty($row['phone'])): ?><div><?php echo htmlspecialchars($row['phone']); ?></div><?php endif; ?>
+            </td>
+            <td><?php echo htmlspecialchars($row['created_at']); ?></td>
+            <td><?php echo nl2br(htmlspecialchars($row['description'])); ?></td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+<?php endif; ?>

--- a/app/views/admin/order_view.php
+++ b/app/views/admin/order_view.php
@@ -1,6 +1,13 @@
 <h1>Pedido #<?php echo $order['id']; ?></h1>
 <p><strong>Cliente:</strong> <?php echo htmlspecialchars($order['customer_name']); ?> — <?php echo htmlspecialchars($order['customer_email']); ?></p>
 <p><strong>Dirección:</strong> <?php echo htmlspecialchars($order['customer_address']); ?> | <strong>Tel:</strong> <?php echo htmlspecialchars($order['customer_phone']); ?></p>
+<?php if(!empty($order['payment_receipt'])): ?>
+  <?php $receiptUrl = rtrim(preg_replace('#/index\.php$#','', BASE_URL), '/') . '/' . ltrim($order['payment_receipt'],'/'); ?>
+  <p><strong>Comprobante:</strong> <a class="btn light" href="<?php echo htmlspecialchars($receiptUrl); ?>" target="_blank" rel="noopener">Ver imagen</a></p>
+  <div style="max-width:320px; margin: 0 0 20px;">
+    <img src="<?php echo htmlspecialchars($receiptUrl); ?>" alt="Comprobante de pago" style="width:100%; border-radius:12px; box-shadow:0 8px 18px rgba(0,0,0,0.12);">
+  </div>
+<?php endif; ?>
 <table class="table">
 <thead><tr><th>Producto</th><th>Cant.</th><th>P.Unit</th><th>Estado</th><th>Subtotal</th></tr></thead>
 <tbody>

--- a/app/views/admin/orders.php
+++ b/app/views/admin/orders.php
@@ -1,6 +1,6 @@
 <h1>Pedidos</h1>
 <table class="table">
-  <thead><tr><th>#</th><th>Cliente</th><th>Fecha</th><th>Total</th><th>Estado</th><th></th></tr></thead>
+  <thead><tr><th>#</th><th>Cliente</th><th>Fecha</th><th>Total</th><th>Estado</th><th>Comprobante</th><th></th></tr></thead>
   <tbody>
   <?php foreach($orders as $o): ?>
     <tr>
@@ -8,7 +8,15 @@
       <td><?php echo htmlspecialchars($o['customer_name']); ?></td>
       <td><?php echo $o['created_at']; ?></td>
       <td>S/ <?php echo number_format($o['total'],2); ?></td>
-      <td><?php echo htmlspecialchars($o['status']); ?></td>
+      <td data-status="<?php echo htmlspecialchars($o['status']); ?>"><?php echo htmlspecialchars($o['status']); ?></td>
+      <td>
+        <?php if(!empty($o['payment_receipt'])): ?>
+          <?php $receiptUrl = rtrim(preg_replace('#/index\.php$#','', BASE_URL), '/') . '/' . ltrim($o['payment_receipt'],'/'); ?>
+          <a class="btn light" href="<?php echo htmlspecialchars($receiptUrl); ?>" target="_blank" rel="noopener">Ver</a>
+        <?php else: ?>
+          —
+        <?php endif; ?>
+      </td>
       <td><a class="btn light" href="<?php echo BASE_URL; ?>?r=admin/order/<?php echo $o['id']; ?>">Ver</a></td>
     </tr>
   <?php endforeach; ?>

--- a/app/views/admin/receipts.php
+++ b/app/views/admin/receipts.php
@@ -1,0 +1,29 @@
+<h1>Comprobantes de Pago</h1>
+<p>Visualiza los comprobantes de pago cargados por los clientes al finalizar su compra.</p>
+
+<?php if(empty($orders)): ?>
+  <p>No hay comprobantes registrados por el momento.</p>
+<?php else: ?>
+  <?php $baseUrl = rtrim(preg_replace('#/index\.php$#','', BASE_URL), '/'); ?>
+  <div class="table-wrap">
+    <table class="table">
+      <thead>
+        <tr><th>#</th><th>Cliente</th><th>Fecha</th><th>Total</th><th>Comprobante</th></tr>
+      </thead>
+      <tbody>
+        <?php foreach($orders as $order): ?>
+          <?php $receiptUrl = $baseUrl . '/' . ltrim($order['payment_receipt'], '/'); ?>
+          <tr>
+            <td><?php echo $order['id']; ?></td>
+            <td><?php echo htmlspecialchars($order['customer_name']); ?></td>
+            <td><?php echo htmlspecialchars($order['created_at']); ?></td>
+            <td>S/ <?php echo number_format($order['total'], 2); ?></td>
+            <td>
+              <a class="btn light" href="<?php echo htmlspecialchars($receiptUrl); ?>" target="_blank" rel="noopener">Ver imagen</a>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </tbody>
+    </table>
+  </div>
+<?php endif; ?>

--- a/app/views/frontend/checkout.php
+++ b/app/views/frontend/checkout.php
@@ -21,15 +21,15 @@ $payAction = BASE_URL . '?r=checkout/pay' . ($inPartial ? '&partial=1' : '');
 <h1>Finalizar compra</h1>
 <?php if(isset($error)): ?><div class="alert">⚠️ <?php echo htmlspecialchars($error); ?></div><?php endif; ?>
 
-<div class="grid" style="grid-template-columns: 1.2fr .8fr; gap:20px">
-  <form class="form" method="post" action="<?php echo $payAction; ?>">
+<div class="checkout-layout">
+  <form class="form checkout-form" method="post" action="<?php echo $payAction; ?>" enctype="multipart/form-data">
 
     <!-- Columna Izquierda: Datos del cliente + Comprobante (dentro del form) -->
     <h3>Datos del cliente</h3>
-    <label>Nombre completo</label><input required name="name">
-    <label>Correo</label><input type="email" required name="email">
-    <label>Teléfono</label><input name="phone">
-    <label>Dirección</label><textarea name="address" rows="3"></textarea>
+    <label>Nombre completo</label><input required name="name" value="<?php echo htmlspecialchars($_POST['name'] ?? ''); ?>">
+    <label>Correo</label><input type="email" required name="email" value="<?php echo htmlspecialchars($_POST['email'] ?? ''); ?>">
+    <label>Teléfono</label><input name="phone" value="<?php echo htmlspecialchars($_POST['phone'] ?? ''); ?>">
+    <label>Dirección</label><textarea name="address" rows="3"><?php echo htmlspecialchars($_POST['address'] ?? ''); ?></textarea>
 
     <h3>Resumen</h3>
     <ul>
@@ -41,7 +41,8 @@ $payAction = BASE_URL . '?r=checkout/pay' . ($inPartial ? '&partial=1' : '');
     <hr>
     
     <h3>Subir Comprobante</h3>
-    <label></label><input type="file" name="image" accept="image/*">
+    <p style="margin:0 0 8px;font-size:14px;color:#555;">Adjunta la foto o captura del pago (formatos permitidos: JPG, PNG, WEBP).</p>
+    <input type="file" class="file-input" name="payment_receipt" accept="image/png,image/jpeg,image/webp" required>
 
     <br><br>
     <button class="btn" type="submit">Confirmar y generar comprobante</button>
@@ -49,7 +50,7 @@ $payAction = BASE_URL . '?r=checkout/pay' . ($inPartial ? '&partial=1' : '');
   </form>
 
   <!-- Columna Derecha: Resumen + Formas de pago (fuera del form, solo informativo) -->
-  <div>
+  <div class="checkout-info">
     
 
     <p><strong>Formas de pago: </strong></p>

--- a/app/views/frontend/complaint.php
+++ b/app/views/frontend/complaint.php
@@ -1,0 +1,40 @@
+<h1>Libro de Reclamaciones</h1>
+<p>En cumplimiento de la normativa vigente, puedes registrar aquí tu reclamo o queja. Nuestro equipo revisará tu solicitud y se comunicará contigo en un plazo máximo de 48 horas hábiles.</p>
+
+<?php if(!empty($error)): ?>
+  <div class="alert">⚠️ <?php echo htmlspecialchars($error); ?></div>
+<?php endif; ?>
+<?php if(!empty($success)): ?>
+  <div class="alert" style="border-left-color:#16a34a;">✅ <?php echo htmlspecialchars($success); ?></div>
+<?php endif; ?>
+
+<?php $oldData = $old ?? []; ?>
+<form class="form" method="post" action="<?php echo BASE_URL; ?>?r=home/complaint_submit">
+  <label>Nombre completo*</label>
+  <input name="full_name" required value="<?php echo htmlspecialchars($oldData['full_name'] ?? ''); ?>">
+
+  <label>Documento de identidad</label>
+  <input name="document" value="<?php echo htmlspecialchars($oldData['document'] ?? ''); ?>">
+
+  <label>Correo electrónico*</label>
+  <input type="email" name="email" required value="<?php echo htmlspecialchars($oldData['email'] ?? ''); ?>">
+
+  <label>Teléfono de contacto</label>
+  <input name="phone" value="<?php echo htmlspecialchars($oldData['phone'] ?? ''); ?>">
+
+  <label>Nº de pedido (opcional)</label>
+  <input name="order_code" value="<?php echo htmlspecialchars($oldData['order_code'] ?? ''); ?>">
+
+  <label>Tipo de registro</label>
+  <?php $type = $oldData['type'] ?? 'Reclamo'; ?>
+  <select name="type">
+    <?php foreach(['Reclamo','Queja','Consulta'] as $option): ?>
+      <option value="<?php echo $option; ?>" <?php if($type === $option) echo 'selected'; ?>><?php echo $option; ?></option>
+    <?php endforeach; ?>
+  </select>
+
+  <label>Detalle*</label>
+  <textarea name="description" rows="5" required><?php echo htmlspecialchars($oldData['description'] ?? ''); ?></textarea>
+
+  <button class="btn" type="submit">Enviar registro</button>
+</form>

--- a/app/views/partials/layout_admin.php
+++ b/app/views/partials/layout_admin.php
@@ -15,6 +15,8 @@
     <nav>
       <a href="<?php echo BASE_URL; ?>?r=admin/dashboard">Inicio</a>
       <a href="<?php echo BASE_URL; ?>?r=admin/orders">Pedidos</a>
+      <a href="<?php echo BASE_URL; ?>?r=admin/receipts">Comprobantes</a>
+      <a href="<?php echo BASE_URL; ?>?r=admin/complaints">Reclamaciones</a>
       <a href="<?php echo BASE_URL; ?>?r=admin/products">Productos</a>
       <a href="<?php echo BASE_URL; ?>?r=admin/categories">Categorías</a>
       <a href="<?php echo BASE_URL; ?>?r=admin/reports">Reportes</a>

--- a/app/views/partials/layout_main.php
+++ b/app/views/partials/layout_main.php
@@ -16,6 +16,7 @@
       <a style="text-shadow: 1.5px 1.5px 1.5px rgba(0, 0, 0, 0.9);" href="<?php echo BASE_URL; ?>?r=product/index">Productos</a>
       <a style="text-shadow: 1.5px 1.5px 1.5px rgba(0, 0, 0, 0.9);" href="<?php echo BASE_URL; ?>?r=home/about">Nosotros</a>
       <a style="text-shadow: 1.5px 1.5px 1.5px rgba(0, 0, 0, 0.9);" href="<?php echo BASE_URL; ?>?r=home/contact">Contacto</a>
+      <a style="text-shadow: 1.5px 1.5px 1.5px rgba(0, 0, 0, 0.9);" href="<?php echo BASE_URL; ?>?r=home/complaint">Libro de reclamaciones</a>
       <a style="text-shadow: 1.5px 1.5px 1.5px rgba(0, 0, 0, 0.9);" href="<?php echo BASE_URL; ?>?r=cart/view">🛒 Carrito (<?php echo isset($_SESSION['cart']) ? array_sum(array_column($_SESSION['cart'], 'qty')) : 0; ?>)</a>
       <a style="text-shadow: 1.5px 1.5px 1.5px rgba(0, 0, 0, 0.9);" href="<?php echo BASE_URL; ?>?r=admin/login" class="admin">cPanel</a>
     </nav>

--- a/db/database.sql
+++ b/db/database.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS orders (
   customer_phone VARCHAR(60) DEFAULT '',
   customer_address VARCHAR(255) DEFAULT '',
   total DECIMAL(10,2) NOT NULL DEFAULT 0,
+  payment_receipt VARCHAR(255) NOT NULL DEFAULT '',
   status ENUM('PENDIENTE','PAGADO','ENVIADO','CANCELADO') DEFAULT 'PENDIENTE',
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
@@ -64,6 +65,19 @@ CREATE TABLE IF NOT EXISTS order_items (
   subtotal DECIMAL(10,2) NOT NULL,
   FOREIGN KEY (order_id) REFERENCES orders(id) ON DELETE CASCADE,
   FOREIGN KEY (product_id) REFERENCES products(id) ON DELETE RESTRICT
+);
+
+-- Complaints (Libro de Reclamaciones)
+CREATE TABLE IF NOT EXISTS complaints (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  full_name VARCHAR(200) NOT NULL,
+  document VARCHAR(60) DEFAULT '',
+  email VARCHAR(150) NOT NULL,
+  phone VARCHAR(60) DEFAULT '',
+  order_code VARCHAR(60) DEFAULT '',
+  type ENUM('Reclamo','Queja','Consulta') DEFAULT 'Reclamo',
+  description TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
 -- Demo data

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -244,6 +244,30 @@ body {
   box-shadow: 0 0 0 2px var(--color-light);
 }
 
+.checkout-layout {
+  display: grid;
+  grid-template-columns: 1.2fr 0.8fr;
+  gap: 20px;
+  align-items: flex-start;
+  margin-top: 20px;
+}
+.checkout-info {
+  background: #fff;
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.06);
+}
+.checkout-form .file-input {
+  width: 100%;
+  padding: 14px;
+  border-radius: 12px;
+  border: 1px dashed #bbb;
+  background: #fafafa;
+}
+.checkout-form button {
+  width: 100%;
+}
+
 /* Tablas */
 .table {
   width: 100%;
@@ -284,6 +308,67 @@ body {
 .badge.success { background: #d1fae5; color: #065f46; }
 .badge.warn { background: #fef3c7; color: #92400e; }
 .badge.danger { background: #fee2e2; color: #991b1b; }
+
+@media (max-width: 900px) {
+  .checkout-layout {
+    grid-template-columns: 1fr;
+  }
+  .checkout-info {
+    order: 2;
+  }
+  .checkout-form {
+    order: 1;
+  }
+}
+
+@media (max-width: 768px) {
+  .site-header .container {
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
+    padding: 12px 16px;
+    height: auto;
+  }
+  .site-header nav {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    justify-content: center;
+  }
+  .site-header nav a {
+    margin: 0;
+    flex: 1 1 calc(50% - 8px);
+    text-align: center;
+  }
+  .hero-slider {
+    height: 48vh;
+  }
+}
+
+@media (max-width: 640px) {
+  .checkout-layout {
+    margin-top: 16px;
+  }
+  .table {
+    display: block;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .btn {
+    width: 100%;
+    text-align: center;
+  }
+}
+
+@media (max-width: 480px) {
+  .site-header nav a {
+    flex: 1 1 100%;
+  }
+  .checkout-info {
+    padding: 16px;
+  }
+}
 
 /* Admin */
 .admin-header {

--- a/public/assets/css/styleproducts.css
+++ b/public/assets/css/styleproducts.css
@@ -172,3 +172,10 @@ body.modal-open { overflow: hidden; }
   .cards-sobre.layout-2x2{ grid-template-columns: 1fr; }
 }
 
+@media (max-width: 640px){
+  .grid{
+    flex-direction: column;
+    align-items: center;
+  }
+}
+

--- a/public/assets/css/stylesadmin.css
+++ b/public/assets/css/stylesadmin.css
@@ -13,6 +13,12 @@ body.admin-body {
   padding: 0 20px;
 }
 
+.table-wrap{
+  width: 100%;
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
 /* ====== HEADER ====== */
 .admin-header {
   background: #0f1833; /* azul oscuro corporativo */
@@ -71,6 +77,36 @@ body.admin-body {
 
 .admin-header nav a[target="_blank"]:hover {
   background: #006f24;
+}
+
+@media (max-width: 960px){
+  .admin-header .container{
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+  .admin-header nav{
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 640px){
+  .admin-header nav{
+    gap: 10px;
+  }
+  .admin-header nav a{
+    flex: 1 1 calc(50% - 10px);
+    text-align: center;
+  }
+  main.container{
+    padding: 20px 16px;
+  }
+}
+
+@media (max-width: 480px){
+  .admin-header nav a{
+    flex: 1 1 100%;
+  }
 }
 
 /* ====== MAIN ====== */


### PR DESCRIPTION
## Summary
- require an image receipt during checkout, persist the uploaded path on each order, and expose receipt links from order listings
- add a public libro de reclamaciones form backed by a new complaints table plus admin views for complaints and receipts
- adjust navigation and CSS to keep the checkout flow, admin tables, and new pages responsive on smaller screens

## Testing
- php -l app/controllers/CheckoutController.php
- php -l app/controllers/AdminController.php
- php -l app/controllers/HomeController.php
- php -l app/models/Order.php
- php -l app/models/Complaint.php

------
https://chatgpt.com/codex/tasks/task_e_68edb5beb124832eb1298ae68cb235d3